### PR TITLE
Update oneSENSE_GUI to work with shinyFiles v0.8.0

### DIFF
--- a/R/oneSENSE_GUI.R
+++ b/R/oneSENSE_GUI.R
@@ -61,7 +61,7 @@ oneSENSE_GUI <- function() {
 
     server <- function(input, output, session) {
 
-    volumes = getVolumes()
+    volumes = getVolumes()()
     shinyDirChoose(input, "directory", roots = volumes, session = session)
     output$directorypath <- renderPrint({
         parseDirPath(roots = volumes, input$directory)


### PR DESCRIPTION
The shinyFiiles function getVolumes() returns a function. The returned function must be called to generate a vector. This fixed the error "Warning: Error in [: object of type 'closure' is not subsettable"